### PR TITLE
Implement "new game" functionality

### DIFF
--- a/__mocks__/electron.ts
+++ b/__mocks__/electron.ts
@@ -22,7 +22,13 @@ class TestIpcRenderer {
   invoke: never;
 
   on(channel: string, listener: TestIpcRendererEventListener) {
-    this._channels[channel].push(listener);
+    const _channel = this._channels[channel];
+
+    if (!_channel) {
+      this._channels[channel] = [listener];
+    } else {
+      _channel.push(listener);
+    }
   }
 
   once: never;
@@ -31,7 +37,7 @@ class TestIpcRenderer {
     const _channel = this._channels[channel];
     if (!_channel) return;
 
-    _channel?.splice(_channel.findIndex(listener), 1);
+    _channel.splice(_channel.findIndex(listener), 1);
   }
 
   removeAllListeners(channel: string) {

--- a/__mocks__/electron.ts
+++ b/__mocks__/electron.ts
@@ -1,0 +1,60 @@
+interface TestIpcRendererEvent {
+  preventDefault: () => void;
+  sender: TestIpcRenderer;
+  senderId: number;
+}
+interface TestChannels {
+  [name: string]: TestIpcRendererEventListener[];
+}
+
+type TestIpcRendererEventListener = (
+  event: TestIpcRendererEvent,
+  ...args: any[]
+) => void;
+
+class TestIpcRenderer {
+  _channels: TestChannels;
+
+  constructor() {
+    this._channels = {};
+  }
+
+  invoke: never;
+
+  on(channel: string, listener: TestIpcRendererEventListener) {
+    this._channels[channel].push(listener);
+  }
+
+  once: never;
+
+  removeListener(channel: string, listener) {
+    const _channel = this._channels[channel];
+    if (!_channel) return;
+
+    _channel?.splice(_channel.findIndex(listener), 1);
+  }
+
+  removeAllListeners(channel: string) {
+    const _channel = this._channels[channel];
+    if (!channel) return;
+
+    while (_channel.length > 0) {
+      _channel.pop();
+    }
+  }
+
+  send(channel: string, ...args: any[]) {
+    const event: TestIpcRendererEvent = {
+      preventDefault: () => {},
+      sender: this,
+      senderId: 0
+    };
+    this._channels[channel]?.forEach(listener => listener(event, ...args));
+  }
+
+  sendSync: never;
+  sendTo: never;
+  sendToHost: never;
+}
+
+export const ipcRenderer = new TestIpcRenderer();

--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = "test-file-stub";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1468,6 +1468,25 @@
         "@babel/plugin-transform-typescript": "^7.8.3"
       }
     },
+    "@babel/runtime": {
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
+      "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
+    "@babel/runtime-corejs3": {
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz",
+      "integrity": "sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.3.tgz",
@@ -2838,6 +2857,12 @@
         "@types/node": ">= 8"
       }
     },
+    "@sheerun/mutationobserver-shim": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
+      "integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw==",
+      "dev": true
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -2884,6 +2909,32 @@
             "ajv-keywords": "^3.4.1"
           }
         }
+      }
+    },
+    "@testing-library/dom": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.16.0.tgz",
+      "integrity": "sha512-lBD88ssxqEfz0wFL6MeUyyWZfV/2cjEZZV3YRpb2IoJRej/4f1jB0TzqIOznTpfR1r34CNesrubxwIlAQ8zgPA==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.8.4",
+        "@sheerun/mutationobserver-shim": "^0.3.2",
+        "@types/testing-library__dom": "^6.12.1",
+        "aria-query": "^4.0.2",
+        "dom-accessibility-api": "^0.3.0",
+        "pretty-format": "^25.1.0",
+        "wait-for-expect": "^3.0.2"
+      }
+    },
+    "@testing-library/react": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.5.0.tgz",
+      "integrity": "sha512-di1b+D0p+rfeboHO5W7gTVeZDIK5+maEgstrZbWZSSvxDyfDRkkyBE1AJR5Psd6doNldluXlCWqXriUfqu/9Qg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.8.4",
+        "@testing-library/dom": "^6.15.0",
+        "@types/testing-library__react": "^9.1.2"
       }
     },
     "@types/babel__core": {
@@ -3069,6 +3120,72 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-1.0.1.tgz",
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
+    },
+    "@types/testing-library__dom": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.14.0.tgz",
+      "integrity": "sha512-sMl7OSv0AvMOqn1UJ6j1unPMIHRXen0Ita1ujnMX912rrOcawe4f7wu0Zt9GIQhBhJvH2BaibqFgQ3lP+Pj2hA==",
+      "dev": true,
+      "requires": {
+        "pretty-format": "^24.3.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+          "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^13.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "13.0.8",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+          "integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+          "integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "ansi-regex": "^4.0.0",
+            "ansi-styles": "^3.2.0",
+            "react-is": "^16.8.4"
+          }
+        },
+        "react-is": {
+          "version": "16.13.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",
+          "integrity": "sha512-GFMtL0vHkiBv9HluwNZTggSn/sCyEt9n02aM0dSAjGGyqyNlAyftYm4phPxdvCigG15JreC5biwxCgTAJZ7yAA==",
+          "dev": true
+        }
+      }
+    },
+    "@types/testing-library__react": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-9.1.3.tgz",
+      "integrity": "sha512-iCdNPKU3IsYwRK9JieSYAiX0+aYDXOGAmrC/3/M7AqqSDKnWWVv07X+Zk1uFSL7cMTUYzv4lQRfohucEocn5/w==",
+      "dev": true,
+      "requires": {
+        "@types/react-dom": "*",
+        "@types/testing-library__dom": "*",
+        "pretty-format": "^25.1.0"
+      }
     },
     "@types/unist": {
       "version": "2.0.3",
@@ -3494,6 +3611,16 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-query": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.0.2.tgz",
+      "integrity": "sha512-S1G1V790fTaigUSM/Gd0NngzEfiMy9uTUfMyHhKhVyy4cH5O/eTuR01ydhGL0z4Za1PXFTRGH3qL8VhUQuEO5w==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.7.4",
+        "@babel/runtime-corejs3": "^7.7.4"
       }
     },
     "arr-diff": {
@@ -5020,6 +5147,12 @@
         }
       }
     },
+    "core-js-pure": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.4.tgz",
+      "integrity": "sha512-epIhRLkXdgv32xIUFaaAry2wdxZYBi6bgM7cB136dzzXXa+dFyRLTZeLUJxnd8ShrmyVXBub63n2NHo2JAt8Cw==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -5690,6 +5823,12 @@
           "dev": true
         }
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.3.0.tgz",
+      "integrity": "sha512-PzwHEmsRP3IGY4gv/Ug+rMeaTIyTJvadCb+ujYXYeIylbHJezIyNToe8KfEgHTCEYyC+/bUghYOGg8yMGlZ6vA==",
+      "dev": true
     },
     "dom-converter": {
       "version": "0.2.0",
@@ -8686,6 +8825,12 @@
         "har-schema": "^2.0.0"
       }
     },
+    "harmony-reflect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.1.tgz",
+      "integrity": "sha512-WJTeyp0JzGtHcuMsi7rw2VwtkvLa+JyfEKJCFyfcS0+CDkjQ5lHPu7zEhFZP+PDSRrEgXa5Ah0l1MbgbE41XjA==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -9071,6 +9216,15 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.14"
+      }
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "dev": true,
+      "requires": {
+        "harmony-reflect": "^1.4.6"
       }
     },
     "ieee754": {
@@ -14423,6 +14577,12 @@
         "regenerate": "^1.4.0"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
+      "dev": true
+    },
     "regenerator-transform": {
       "version": "0.14.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.14.1.tgz",
@@ -17174,6 +17334,12 @@
         "webidl-conversions": "^4.0.2",
         "xml-name-validator": "^3.0.0"
       }
+    },
+    "wait-for-expect": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz",
+      "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==",
+      "dev": true
     },
     "walker": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,12 @@
     "last 2 Safari versions",
     "last 2 Edge versions"
   ],
+  "jest": {
+    "moduleNameMapper": {
+      "\\.(jpg|jpeg|png|gif|svg|ttf|ico)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(css)$": "identity-obj-proxy"
+    }
+  },
   "dependencies": {
     "electron-squirrel-startup": "^1.0.0"
   },
@@ -44,6 +50,7 @@
     "@electron-forge/publisher-github": "^6.0.0-beta.50",
     "@marshallofsound/webpack-asset-relocator-loader": "^0.5.0",
     "@teamsupercell/typings-for-css-modules-loader": "^2.1.0",
+    "@testing-library/react": "^9.5.0",
     "@types/classnames": "^2.2.9",
     "@types/electron": "^1.6.10",
     "@types/jest": "^25.1.2",
@@ -61,6 +68,7 @@
     "eslint-plugin-jest": "^23.7.0",
     "eslint-plugin-promise": "^4.2.1",
     "fork-ts-checker-webpack-plugin": "^4.0.4",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^25.1.0",
     "node-loader": "^0.6.0",
     "postcss-loader": "^3.0.0",

--- a/src/components/Board.test.tsx
+++ b/src/components/Board.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { ipcRenderer } from "electron";
+import { act } from "react-dom/test-utils";
+
+import {
+  fireEvent,
+  render,
+  seedRandom,
+  restoreRandom
+} from "../../utils/test.utils";
+
+import { IPC_MESSAGE } from "../lib/constants";
+
+import Board from "./Board";
+
+beforeEach(() => {
+  seedRandom();
+});
+
+afterEach(() => {
+  restoreRandom();
+});
+
+it("should render", () => {
+  render(<Board />);
+
+  const table = document.getElementsByTagName("table")[0];
+  expect(table).toBeTruthy();
+});
+
+it('should reset on "new game"', () => {
+  render(<Board />);
+
+  const table = document.getElementsByTagName("table")[0];
+  expect(table).toBeTruthy();
+
+  const cell = document.querySelector(".cell");
+  if (!cell) throw new Error("No cells!");
+
+  seedRandom(1337);
+
+  fireEvent.click(cell);
+
+  // Make sure there are revealed cells before we reconfigure the board.
+  const revealedCells = document.querySelectorAll(".revealed");
+  expect(revealedCells.length).toBe(53);
+
+  act(() => {
+    ipcRenderer.send(IPC_MESSAGE.NEW_GAME);
+  });
+
+  expect(document.querySelectorAll(".revealed").length).toBe(0);
+});

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,10 +1,12 @@
-import React, { useReducer } from "react";
+import { ipcRenderer } from "electron";
+import React, { useEffect, useReducer } from "react";
 
-import { CONFIG_EASY } from "../lib/constants";
+import { CONFIG_EASY, IPC_MESSAGE } from "../lib/constants";
 
 import {
   init,
   reducer as boardReducer,
+  reconfigureBoard,
   revealCell,
   turnCellState
 } from "../logic/board";
@@ -15,6 +17,13 @@ import styles from "./Board.css";
 
 export default () => {
   const [state, dispatch] = useReducer(boardReducer, CONFIG_EASY, init);
+
+  useEffect(() => {
+    // Listen for the "new game" message from the main process.
+    ipcRenderer.on(IPC_MESSAGE.NEW_GAME, (event, arg) => {
+      dispatch(reconfigureBoard(state.config));
+    });
+  }, []);
 
   return (
     <table className={styles.board}>

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -19,10 +19,16 @@ export default () => {
   const [state, dispatch] = useReducer(boardReducer, CONFIG_EASY, init);
 
   useEffect(() => {
-    // Listen for the "new game" message from the main process.
-    ipcRenderer.on(IPC_MESSAGE.NEW_GAME, (event, arg) => {
+    const newGameListener = (event, arg) => {
       dispatch(reconfigureBoard(state.config));
-    });
+    };
+
+    // Listen for the "new game" message from the main process.
+    ipcRenderer.on(IPC_MESSAGE.NEW_GAME, newGameListener);
+
+    return () => {
+      ipcRenderer.removeListener(IPC_MESSAGE.NEW_GAME, newGameListener);
+    };
   }, []);
 
   return (

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -19,7 +19,7 @@ export default () => {
   const [state, dispatch] = useReducer(boardReducer, CONFIG_EASY, init);
 
   useEffect(() => {
-    const newGameListener = (event, arg) => {
+    const newGameListener = () => {
       dispatch(reconfigureBoard(state.config));
     };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
 import { app, BrowserWindow, Menu, MenuItemConstructorOptions } from "electron";
+
+import { IPC_MESSAGE } from "./lib/constants";
+
 declare const MAIN_WINDOW_WEBPACK_ENTRY: any;
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
@@ -6,53 +9,63 @@ if (require("electron-squirrel-startup")) {
   app.quit();
 }
 
-const menuTemplate: MenuItemConstructorOptions[] = [
-  {
-    label: "Game",
-    submenu: [
-      { label: "New", accelerator: "F2", enabled: false },
-      { type: "separator" },
-      { label: "Beginner", type: "checkbox", enabled: false, checked: true },
-      { label: "Intermediate", type: "checkbox", enabled: false },
-      { label: "Expert", type: "checkbox", enabled: false },
-      { label: "Customer...", type: "checkbox", enabled: false },
-      { type: "separator" },
-      { label: "Marks (?)", type: "checkbox", enabled: false, checked: true },
-      { label: "Color", type: "checkbox", enabled: false, checked: true },
-      { label: "Sound", type: "checkbox", enabled: false },
-      { type: "separator" },
-      { label: "Best Times...", enabled: false },
-      { type: "separator" },
-      { label: "Exit", role: "quit" }
-    ]
-  },
-  {
-    label: "Help",
-    submenu: [
-      { label: "Contents", accelerator: "F1", enabled: false },
-      { label: "Search for Help on...", enabled: false },
-      { label: "Using Help", enabled: false },
-      { type: "separator" },
-      { label: "About Minesweeper...", enabled: false }
-    ]
-  }
-];
-
 const isMac = process.platform === "darwin";
-
-if (isMac) {
-  menuTemplate.unshift({ role: "appMenu" });
-}
-
-const menu = Menu.buildFromTemplate(menuTemplate);
-Menu.setApplicationMenu(menu);
 
 const createWindow = () => {
   // Create the browser window.
   const mainWindow = new BrowserWindow({
     height: 600,
+    webPreferences: {
+      nodeIntegration: true
+    },
     width: 800
   });
+
+  const menuTemplate: MenuItemConstructorOptions[] = [
+    {
+      label: "Game",
+      submenu: [
+        {
+          label: "New",
+          accelerator: "F2",
+          click: () => {
+            // Send a message to the renderer process.
+            mainWindow.webContents.send(IPC_MESSAGE.NEW_GAME);
+          }
+        },
+        { type: "separator" },
+        { label: "Beginner", type: "checkbox", enabled: false, checked: true },
+        { label: "Intermediate", type: "checkbox", enabled: false },
+        { label: "Expert", type: "checkbox", enabled: false },
+        { label: "Customer...", type: "checkbox", enabled: false },
+        { type: "separator" },
+        { label: "Marks (?)", type: "checkbox", enabled: false, checked: true },
+        { label: "Color", type: "checkbox", enabled: false, checked: true },
+        { label: "Sound", type: "checkbox", enabled: false },
+        { type: "separator" },
+        { label: "Best Times...", enabled: false },
+        { type: "separator" },
+        { label: "Exit", role: "quit" }
+      ]
+    },
+    {
+      label: "Help",
+      submenu: [
+        { label: "Contents", accelerator: "F1", enabled: false },
+        { label: "Search for Help on...", enabled: false },
+        { label: "Using Help", enabled: false },
+        { type: "separator" },
+        { label: "About Minesweeper...", enabled: false }
+      ]
+    }
+  ];
+
+  if (isMac) {
+    menuTemplate.unshift({ role: "appMenu" });
+  }
+
+  const menu = Menu.buildFromTemplate(menuTemplate);
+  Menu.setApplicationMenu(menu);
 
   // and load the index.html of the app.
   mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -41,3 +41,7 @@ export const CONFIG_EXPERT: MinesweeperConfig = { x: 30, y: 16, mines: 99 };
  * configuration is loaded.
  */
 export const CONFIG_DEFAULT: MinesweeperConfig = { x: 0, y: 0, mines: 0 };
+
+export enum IPC_MESSAGE {
+  NEW_GAME = "new-game"
+}

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,4 @@
-import seedrandom from "seedrandom";
-
+import {seedRandom, restoreRandom} from '../../utils/test.utils'
 import { MinesweeperBoard } from "../types";
 
 import {
@@ -26,10 +25,6 @@ let __defaultBoard = getBoard(testConfig);
 const cloneBoard = (board: MinesweeperBoard) =>
   board.map(row => row.map(cell => ({ ...cell })));
 
-const __originalRandom = Math.random;
-const seedRandom = (seed: any = "minesweeper-react") =>
-  (global.Math.random = seedrandom(seed));
-const restoreRandom = () => (global.Math.random = __originalRandom);
 const seededMineCoords = [
   { x: 0, y: 3 },
   { x: 1, y: 4 },

--- a/src/logic/board/index.ts
+++ b/src/logic/board/index.ts
@@ -22,11 +22,7 @@ interface BoardState {
   board: MinesweeperBoard;
 }
 
-/**
- * Action creator for `RECONFIGURE_BOARD`.
- * @param {MinesweeperConfig} configuration
- * @returns {{type: string, configuration: MinesweeperConfig}}
- */
+/** Action creator for `RECONFIGURE_BOARD`. */
 export const reconfigureBoard = (
   configuration: MinesweeperConfig
 ): ReconfigureBoardAction => {
@@ -36,9 +32,7 @@ export const reconfigureBoard = (
   };
 };
 
-/**
- * Action creator for `REVEAL_CELL`.
- */
+/** Action creator for `REVEAL_CELL`. */
 export const revealCell = (x: number, y: number): RevealCellAction => {
   return {
     type: REVEAL_CELL,
@@ -47,12 +41,7 @@ export const revealCell = (x: number, y: number): RevealCellAction => {
   };
 };
 
-/**
- * Action creator for `TURN_CELL_STATE`.
- * @param {number} x
- * @param {number} y
- * @returns {{type: string, x: number, y: number}}
- */
+/** Action creator for `TURN_CELL_STATE`. */
 export const turnCellState = (x: number, y: number): TurnCellStateAction => {
   return {
     type: TURN_CELL_STATE,
@@ -63,10 +52,6 @@ export const turnCellState = (x: number, y: number): TurnCellStateAction => {
 
 /**
  * Merges an update into the specified {@link MinesweeperCell} in a {@link MinesweeperBoard}.
- * @param {MinesweeperBoard} board
- * @param {number} x
- * @param {number} y
- * @param {Object} mod
  * @returns {MinesweeperBoard} A _new_ board.
  * @throws {OutOfBoundsError}
  */

--- a/utils/test.utils.ts
+++ b/utils/test.utils.ts
@@ -1,0 +1,17 @@
+import seedrandom from 'seedrandom'
+import { render, RenderOptions } from "@testing-library/react";
+
+const customRender = (ui: React.ReactElement, options?: RenderOptions) =>
+  render(ui, {
+    // wrapper: AllTheProviders,
+    ...options
+  });
+
+const __originalRandom = Math.random;
+export const seedRandom = (seed: any = "minesweeper-react") =>
+  (global.Math.random = seedrandom(seed));
+export const restoreRandom = () => (global.Math.random = __originalRandom);
+
+export * from "@testing-library/react";
+
+export { customRender as render };


### PR DESCRIPTION
Closes #18 
- Defers menu creation until after the `BrowserWindow` has been defined.
- Sets up an IPC message between main and renderer processes to enable resetting the game from the menu.
- Adds `@testing-library/react` and setup, as well as a basic render test for `Board`.
- Adds a test for `Board` that ensures the "new game" functionality is working.