### PR TITLE
Closes #11 - Hit a mine, lose the game

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,7 +1,7 @@
 import { ipcRenderer } from "electron";
 import React, { useEffect, useReducer } from "react";
 
-import { CONFIG_EASY, IPC_MESSAGE } from "../lib/constants";
+import { CONFIG_EASY, IPC_MESSAGE, GAME_STATE } from "../lib/constants";
 
 import {
   init,
@@ -31,6 +31,20 @@ export default () => {
     };
   }, []);
 
+  const onCellClick = (x: number, y: number) => {
+    if (state.gameState < GAME_STATE.LOSE) {
+      // The game hasn't been won or lost yet.
+      dispatch(revealCell(x, y))
+    }
+  }
+
+  const onCellRightClick = (x: number, y: number) => {
+    if (state.gameState < GAME_STATE.LOSE) {
+      // The game hasn't been won or lost yet.
+      dispatch(turnCellState(x, y))
+    }
+  }
+
   return (
     <table className={styles.board}>
       <tbody>
@@ -41,8 +55,8 @@ export default () => {
                 hasMine={cell.hasMine}
                 key={`cell_${j}`}
                 mineCount={cell.mineCount}
-                onClick={() => dispatch(revealCell(j, i))}
-                onRightClick={() => dispatch(turnCellState(j, i))}
+                onClick={() => onCellClick(j, i)}
+                onRightClick={() => onCellRightClick(j, i)}
                 state={cell.state}
                 x={j}
                 y={i}

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,7 @@ const createWindow = () => {
         { label: "Beginner", type: "checkbox", enabled: false, checked: true },
         { label: "Intermediate", type: "checkbox", enabled: false },
         { label: "Expert", type: "checkbox", enabled: false },
-        { label: "Customer...", type: "checkbox", enabled: false },
+        { label: "Custom...", type: "checkbox", enabled: false },
         { type: "separator" },
         { label: "Marks (?)", type: "checkbox", enabled: false, checked: true },
         { label: "Color", type: "checkbox", enabled: false, checked: true },

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,7 +3,7 @@ import { MinesweeperConfig } from "../types";
 export enum CELL_STATE {
   /**
    * Initial state of all [Cells](Cell). Defined as the absence of all other state.
-   * */
+   */
   DEFAULT,
   /**
    * The user has placed a flag on this {@link MinesweeperCell}. Flagged [Cells](Cell)
@@ -42,6 +42,21 @@ export const CONFIG_EXPERT: MinesweeperConfig = { x: 30, y: 16, mines: 99 };
  */
 export const CONFIG_DEFAULT: MinesweeperConfig = { x: 0, y: 0, mines: 0 };
 
+/**
+ * Enum respresenting the overall game state.
+ */
+export enum GAME_STATE {
+  /** The default state of a board before it has been seeded with mines. */
+  DEFAULT,
+  /** The state of a board after it has been seeded with mines. */
+  SEEDED,
+  /** A state representing the player having won. B) */
+  WIN,
+  /** A state representing the player having lost. X( */
+  LOSE
+}
+
+/** Enum representing the Electron IPC message channels. */
 export enum IPC_MESSAGE {
   NEW_GAME = "new-game"
 }

--- a/src/logic/board/__snapshots__/index.test.ts.snap
+++ b/src/logic/board/__snapshots__/index.test.ts.snap
@@ -432,7 +432,7 @@ Object {
     "x": 9,
     "y": 9,
   },
-  "seeded": false,
+  "gameState": 0,
 }
 `;
 
@@ -2877,7 +2877,7 @@ Object {
     "x": 30,
     "y": 16,
   },
-  "seeded": false,
+  "gameState": 0,
 }
 `;
 
@@ -4202,6 +4202,6 @@ Object {
     "x": 16,
     "y": 16,
   },
-  "seeded": false,
+  "gameState": 0,
 }
 `;

--- a/src/logic/board/index.test.ts
+++ b/src/logic/board/index.test.ts
@@ -23,8 +23,8 @@ describe("RECONFIGURE_BOARD", () => {
     const result = reducer(stateBefore, action);
     expect(result).toEqual({
       ...stateBefore,
-      config: CONFIG_DEFAULT,
-      board: []
+      board: [],
+      config: CONFIG_DEFAULT
     });
   });
 

--- a/src/logic/board/index.ts
+++ b/src/logic/board/index.ts
@@ -14,12 +14,12 @@ import {
   placeMines,
   OutOfBoundsError
 } from "../../lib/utils";
-import { CELL_STATE } from "../../lib/constants";
+import { CELL_STATE, GAME_STATE } from "../../lib/constants";
 
 interface BoardState {
-  config: MinesweeperConfig;
-  seeded: boolean;
   board: MinesweeperBoard;
+  config: MinesweeperConfig;
+  gameState: GAME_STATE;
 }
 
 /** Action creator for `RECONFIGURE_BOARD`. */
@@ -74,10 +74,11 @@ export const modifyCell = (
   });
 };
 
+/** Creates a fresh `BoardState` from the provided `MinesweeperConfig`. */
 export const init = (config: MinesweeperConfig): BoardState => ({
-  seeded: false,
+  board: getBoard(config),
   config,
-  board: getBoard(config)
+  gameState: GAME_STATE.DEFAULT,
 });
 
 export function reducer(state: BoardState, action: BoardAction): BoardState {
@@ -91,7 +92,8 @@ export function reducer(state: BoardState, action: BoardAction): BoardState {
       let newBoard = modifyCell(state.board, x, y, {
         state: CELL_STATE.REVEALED
       });
-      if (!state.seeded) {
+      if (state.gameState === GAME_STATE.DEFAULT) {
+        // Seed the board.
         // TODO: Split this out into a different action so this one is idempotent.
         placeMines(state.config, newBoard, x, y);
       }
@@ -102,14 +104,14 @@ export function reducer(state: BoardState, action: BoardAction): BoardState {
         cascadeCells(state.config, newBoard, x, y);
         return {
           ...state,
-          seeded: true,
-          board: newBoard
+          board: newBoard,
+          gameState: GAME_STATE.SEEDED,
         };
       } else {
         return {
           ...state,
-          seeded: true,
-          board: newBoard
+          board: newBoard,
+          gameState: GAME_STATE.SEEDED
         };
       }
     }

--- a/src/logic/board/index.ts
+++ b/src/logic/board/index.ts
@@ -78,7 +78,7 @@ export const modifyCell = (
 export const init = (config: MinesweeperConfig): BoardState => ({
   board: getBoard(config),
   config,
-  gameState: GAME_STATE.DEFAULT,
+  gameState: GAME_STATE.DEFAULT
 });
 
 export function reducer(state: BoardState, action: BoardAction): BoardState {
@@ -99,13 +99,20 @@ export function reducer(state: BoardState, action: BoardAction): BoardState {
       }
 
       const cell = newBoard[y][x];
-      if (cell.mineCount === 0 && !cell.hasMine) {
+      if (cell.hasMine) {
+        // Game lose! X(
+        return {
+          ...state,
+          board: newBoard,
+          gameState: GAME_STATE.LOSE
+        };
+      } else if (cell.mineCount === 0) {
         // Cell cascade.
         cascadeCells(state.config, newBoard, x, y);
         return {
           ...state,
           board: newBoard,
-          gameState: GAME_STATE.SEEDED,
+          gameState: GAME_STATE.SEEDED
         };
       } else {
         return {


### PR DESCRIPTION
- Adds `GAME_STATE` enum to represent various game states:
  - `DEFAULT`: unseeded
  - `SEEDED`: seeded
  - `LOSE`: lost
  - `WIN`: won
- Adds `gameState` to `BoardState`, doing away with `seeded` flag in the process.
  - The new "game state" concept supersedes the flag.
- Adds logic to change `gameState` to `LOSE` when a cell with a mine is revealed.
- Adds a condition in the click handlers for cells to do nothing if the game is concluded.

**TODO**: add unit tests for _at least_ the `REVEAL_CELL` action.