### PR TITLE
Closes #12 - Winning

### DIFF
--- a/src/components/Tray.test.tsx
+++ b/src/components/Tray.test.tsx
@@ -111,6 +111,25 @@ describe("Tray", () => {
       const result = getByTestId(MINES_LEFT_ID);
       expect(result.innerHTML).toBe(String(CONFIG_EASY.mines - 2));
     });
+
+    it("should be set to 0 when the game is won", () => {
+      const board = getSeededBoard(CONFIG_EASY);
+
+      const { getByTestId, rerender } = render(
+        <TestMinesLeft board={board} gameState={GAME_STATE.SEEDED} />
+      );
+
+      // First, make sure `minesLeft` is non-zero.
+      expect(getByTestId(MINES_LEFT_ID).innerHTML).toBe(
+        String(CONFIG_EASY.mines)
+      );
+
+      // Then simply set the state to WIN.
+      rerender(<TestMinesLeft board={board} gameState={GAME_STATE.WIN} />);
+
+      // And make sure `minesLeft` was set to 0.
+      expect(getByTestId(MINES_LEFT_ID).innerHTML).toBe(String(0));
+    });
   });
 
   describe("seconds", () => {

--- a/src/components/Tray.tsx
+++ b/src/components/Tray.tsx
@@ -26,13 +26,15 @@ interface TrayProps {
  * Accepts a render prop as `children`.
  */
 export const Tray: React.FC<TrayProps> = ({ board, children, gameState }) => {
-  const [minesLeft, setMinesLeft] = useState(getMineDisplayCount(board));
+  const [minesLeft, setMinesLeft] = useState(
+    getMineDisplayCount(board, gameState)
+  );
   const [seconds, setSeconds] = useState(0);
 
   // Calculate number of unflagged mines left.
   useEffect(() => {
-    setMinesLeft(getMineDisplayCount(board));
-  }, [board]);
+    setMinesLeft(getMineDisplayCount(board, gameState));
+  }, [board, gameState]);
 
   // Set up and manage the timer.
   useEffect(() => {

--- a/src/components/Tray.tsx
+++ b/src/components/Tray.tsx
@@ -85,6 +85,7 @@ export const XPTray: React.FC<XPTrayProps> = ({
             {/* HUD */}
             <div className={classnames(styles.slot, styles.hud)}>
               <p className={styles.display}>
+                {/* TODO: "0-X" bug for negative numbers. */}
                 <span>{String(minesLeft).padStart(3, "0")}</span>
               </p>
               <p className={styles.display}>

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -763,7 +763,7 @@ describe("determineBoardState", () => {
     let didIt = false;
     for (const row of board) {
       for (const cell of row) {
-        // Reveal the first cell we find
+        // Reveal the first cell we find.
         if (cell.hasMine) {
           cell.state = CELL_STATE.REVEALED;
           didIt = true;

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -14,8 +14,9 @@ import {
   GAME_STATE,
 } from "./constants";
 import {
-  determineBoardState,
   chordCells,
+  determineBoardState,
+  flagAllMines,
   forEachAdjacentCell,
   getBoard,
   getMineDisplayCount,
@@ -646,21 +647,28 @@ describe("getMineDisplayCount", () => {
   });
 
   it("should return 0 for an empty board", () => {
-    expect(getMineDisplayCount([])).toBe(0);
-    expect(getMineDisplayCount(getBoard(CONFIG_DEFAULT))).toBe(0);
-    expect(getMineDisplayCount(getBoard(CONFIG_EASY))).toBe(0);
+    expect(getMineDisplayCount([], GAME_STATE.DEFAULT)).toBe(0);
+    expect(
+      getMineDisplayCount(getBoard(CONFIG_DEFAULT), GAME_STATE.DEFAULT)
+    ).toBe(0);
+    expect(getMineDisplayCount(getBoard(CONFIG_EASY), GAME_STATE.DEFAULT)).toBe(
+      0
+    );
   });
 
   it("should count mines", () => {
-    expect(getMineDisplayCount(getSeededBoard(CONFIG_EASY))).toBe(
-      CONFIG_EASY.mines
-    );
-    expect(getMineDisplayCount(getSeededBoard(CONFIG_INTERMEDIATE))).toBe(
-      CONFIG_INTERMEDIATE.mines
-    );
-    expect(getMineDisplayCount(getSeededBoard(CONFIG_EXPERT))).toBe(
-      CONFIG_EXPERT.mines
-    );
+    expect(
+      getMineDisplayCount(getSeededBoard(CONFIG_EASY), GAME_STATE.DEFAULT)
+    ).toBe(CONFIG_EASY.mines);
+    expect(
+      getMineDisplayCount(
+        getSeededBoard(CONFIG_INTERMEDIATE),
+        GAME_STATE.DEFAULT
+      )
+    ).toBe(CONFIG_INTERMEDIATE.mines);
+    expect(
+      getMineDisplayCount(getSeededBoard(CONFIG_EXPERT), GAME_STATE.DEFAULT)
+    ).toBe(CONFIG_EXPERT.mines);
   });
 
   it("should subtract flags from mines", () => {
@@ -670,7 +678,9 @@ describe("getMineDisplayCount", () => {
     board[0][0].state = CELL_STATE.FLAGGED;
     board[0][1].state = CELL_STATE.FLAGGED;
 
-    expect(getMineDisplayCount(board)).toBe(CONFIG_EASY.mines - 2);
+    expect(getMineDisplayCount(board, GAME_STATE.DEFAULT)).toBe(
+      CONFIG_EASY.mines - 2
+    );
   });
 
   it("should allow returning a negative number", () => {
@@ -689,7 +699,13 @@ describe("getMineDisplayCount", () => {
     board[1][0].state = CELL_STATE.FLAGGED;
     board[1][1].state = CELL_STATE.FLAGGED;
 
-    expect(getMineDisplayCount(board)).toBe(-1);
+    expect(getMineDisplayCount(board, GAME_STATE.DEFAULT)).toBe(-1);
+  });
+
+  it("should return 0 if `gameState` is `WIN`", () => {
+    const board = getSeededBoard(CONFIG_EASY);
+
+    expect(getMineDisplayCount(board, GAME_STATE.WIN)).toBe(0);
   });
 });
 
@@ -775,5 +791,41 @@ describe("determineBoardState", () => {
     }
 
     expect(determineBoardState(board)).toBe(GAME_STATE.LOSE);
+  });
+});
+
+describe("flagAllMines", () => {
+  it("should flag all mines", () => {
+    const board = getSeededBoard(CONFIG_EASY);
+
+    flagAllMines(board);
+
+    for (const row of board) {
+      for (const cell of row) {
+        if (cell.hasMine) {
+          expect(cell.state).toBe(CELL_STATE.FLAGGED);
+        }
+      }
+    }
+  });
+
+  it("should not interfere with cells that don't have mines", () => {
+    const board = getSeededBoard(CONFIG_EASY);
+
+    const boardBefore = JSON.parse(JSON.stringify(board));
+
+    flagAllMines(board);
+
+    for (let j = 0; j < board.length; j++) {
+      const row = board[j];
+
+      for (let i = 0; i < row.length; i++) {
+        const cell = row[i];
+
+        if (!cell.hasMine) {
+          expect(cell.state).toBe(boardBefore[j][i].state);
+        }
+      }
+    }
   });
 });

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -779,7 +779,7 @@ describe("determineBoardState", () => {
     let didIt = false;
     for (const row of board) {
       for (const cell of row) {
-        // Reveal the first cell we find.
+        // Reveal the first mine we find.
         if (cell.hasMine) {
           cell.state = CELL_STATE.REVEALED;
           didIt = true;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -379,7 +379,12 @@ function _chordCells(
  * Counts how many mines are on the board, subtracting the number of flags that
  *  have been placed.
  */
-export function getMineDisplayCount(board: MinesweeperBoard): number {
+export function getMineDisplayCount(
+  board: MinesweeperBoard,
+  gameState: GAME_STATE
+): number {
+  if (gameState === GAME_STATE.WIN) return 0;
+
   let _numberOfMines = 0;
   let _numberOfFlags = 0;
 
@@ -394,7 +399,7 @@ export function getMineDisplayCount(board: MinesweeperBoard): number {
 }
 
 /**
- * Determines whether or not a board is in the win condition.
+ * Determines what state the game is in from the board.
  */
 export function determineBoardState(board: MinesweeperBoard): GAME_STATE {
   let isSeeded = false;
@@ -440,6 +445,21 @@ export function determineBoardState(board: MinesweeperBoard): GAME_STATE {
     return isSeeded ? GAME_STATE.SEEDED : GAME_STATE.DEFAULT;
   } else {
     return GAME_STATE.WIN;
+  }
+}
+
+/**
+ * Sets the `state` of all cells that have mines to `FLAGGED`.
+ * - This is to be called at the end of the game confirm the placement of mines
+ *   to the user in case they didn't flag them.
+ * 
+ * **Warning:** This is <u>not</u> a pure function.
+ */
+export function flagAllMines(board: MinesweeperBoard): void {
+  for (const row of board) {
+    for (const cell of row) {
+      if (cell.hasMine) cell.state = CELL_STATE.FLAGGED;
+    }
   }
 }
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,9 +1,9 @@
 import {
   MinesweeperConfig,
   MinesweeperBoard,
-  forEachAdjacentCellCallback
+  forEachAdjacentCellCallback,
 } from "../types";
-import { CELL_STATE } from "./constants";
+import { CELL_STATE, GAME_STATE } from "./constants";
 
 // TODO: Derive more information from boards instead of requiring config to always be passed in.
 
@@ -24,7 +24,7 @@ import { CELL_STATE } from "./constants";
  * console.log(isConfigValid({ x: 5, y: 5, mines: 1337 })); // false
  * console.log(isConfigValid({ x: "5", y: "5", mines: "13" })); // false
  */
-export const isConfigValid = (config: MinesweeperConfig): boolean => {
+export function isConfigValid(config: MinesweeperConfig): boolean {
   return (
     !isNaN(config.x) &&
     !isNaN(config.y) &&
@@ -34,7 +34,7 @@ export const isConfigValid = (config: MinesweeperConfig): boolean => {
     config.mines >= 0 &&
     config.mines <= config.x * config.y
   );
-};
+}
 
 /**
  * Determines if the supplied `x` and `y` coordinates are out of bounds for the
@@ -56,14 +56,14 @@ export const isConfigValid = (config: MinesweeperConfig): boolean => {
  *
  * isOutOfBounds(invalidConfig, 10, -1); // throws InvalidConfigError
  */
-export const isOutOfBounds = (
+export function isOutOfBounds(
   config: MinesweeperConfig,
   x: number,
   y: number
-): boolean => {
+): boolean {
   if (!isConfigValid(config)) throw new InvalidConfigError(config);
   return x < 0 || x >= config.x || y < 0 || y >= config.y;
-};
+}
 
 /**
  * Generates the 2-dimensional {@link Array} representing the board using the
@@ -84,7 +84,7 @@ export const isOutOfBounds = (
  *
  * getBoard(invalidConfig); // throws InvalidConfigError
  */
-export const getBoard = (config: MinesweeperConfig): MinesweeperBoard => {
+export function getBoard(config: MinesweeperConfig): MinesweeperBoard {
   if (!isConfigValid(config)) throw new InvalidConfigError(config);
 
   const board = [];
@@ -99,14 +99,14 @@ export const getBoard = (config: MinesweeperConfig): MinesweeperBoard => {
       column.push({
         state: CELL_STATE.DEFAULT,
         hasMine: false,
-        mineCount: 0
+        mineCount: 0,
       });
     }
     board.push(column);
   }
 
   return board;
-};
+}
 
 /**
  * Executes the `action` callback for every cell adjacent to the target `x` and
@@ -136,13 +136,13 @@ export const getBoard = (config: MinesweeperConfig): MinesweeperBoard => {
  * //  { x: 1, y: 5 }
  * //  { x: 1, y: 6 }
  */
-export const forEachAdjacentCell = (
+export function forEachAdjacentCell(
   config: MinesweeperConfig,
   board: MinesweeperBoard,
   x: number,
   y: number,
   action: forEachAdjacentCellCallback
-): void => {
+): void {
   if (!isConfigValid(config)) throw new InvalidConfigError(config);
   if (isOutOfBounds(config, x, y)) throw new OutOfBoundsError(x, y);
 
@@ -156,7 +156,7 @@ export const forEachAdjacentCell = (
       action(board[checkY][checkX], checkX, checkY);
     }
   }
-};
+}
 
 /**
  * Modifies the given {@link MinesweeperBoard} by setting `hasMine` to `true` for the
@@ -210,12 +210,12 @@ export const forEachAdjacentCell = (
  * placeMine(invalidConfig, [][], 0, 0) // throws InvalidConfigError
  * placeMine(myConfig, myBoard, 100, 3) // throws OutOfBoundsError
  */
-export const placeMine = (
+export function placeMine(
   config: MinesweeperConfig,
   board: MinesweeperBoard,
   x: number,
   y: number
-): boolean => {
+): boolean {
   if (!isConfigValid(config)) throw new InvalidConfigError(config);
   if (isOutOfBounds(config, x, y)) throw new OutOfBoundsError(x, y);
 
@@ -228,10 +228,10 @@ export const placeMine = (
   cell.hasMine = true;
 
   // Update the mineCount of adjacent cells.
-  forEachAdjacentCell(config, board, x, y, cell => cell.mineCount++);
+  forEachAdjacentCell(config, board, x, y, (cell) => cell.mineCount++);
 
   return true;
-};
+}
 
 // TODO: Rename so as not to be so similar to `placeMine`.
 /**
@@ -262,12 +262,12 @@ export const placeMine = (
  * // `myBoard` will now be randomly populated with mines and the cells'
  * //  `mineCount` will be set.
  */
-export const placeMines = (
+export function placeMines(
   config: MinesweeperConfig,
   board: MinesweeperBoard,
   seedX: number,
   seedY: number
-): MinesweeperBoard => {
+): MinesweeperBoard {
   // TODO: Rename `seedX`/`seedY`; the names make it sound like this function is idempotent.
   if (!isConfigValid(config)) throw new InvalidConfigError(config);
   if (isOutOfBounds(config, seedX, seedY))
@@ -287,7 +287,7 @@ export const placeMines = (
         config,
         board,
         seedX,
-        seedY
+        seedY,
       });
       continue;
     }
@@ -295,7 +295,7 @@ export const placeMines = (
   }
 
   return board;
-};
+}
 
 /**
  * If the origin {@link MinesweeperCell} specified by `x` and `y` is "empty" (has a
@@ -340,18 +340,18 @@ export const placeMines = (
  * chordCells(invalidConfig, [][], 0, 0) // throws InvalidConfigError
  * chordCells(myConfig, myBoard, 100, 100) // throws OutOfBoundsError
  */
-export const chordCells = (
+export function chordCells(
   config: MinesweeperConfig,
   board: MinesweeperBoard,
   x: number,
   y: number
-): void => {
+): void {
   if (!isConfigValid(config)) throw new InvalidConfigError(config);
   if (isOutOfBounds(config, x, y)) throw new OutOfBoundsError(x, y);
 
   // If the target is empty, begin the recursion.
   if (board[y][x].mineCount === 0) _chordCells(config, board, x, y);
-};
+}
 
 /**
  * Internal recursion callback for {@link chordCells}.
@@ -362,24 +362,24 @@ export const chordCells = (
  * @returns {void}
  * @private
  */
-const _chordCells = (
+function _chordCells(
   config: MinesweeperConfig,
   board: MinesweeperBoard,
   x: number,
   y: number
-): void => {
+): void {
   forEachAdjacentCell(config, board, x, y, (cell, _x, _y) => {
     if (cell.state === CELL_STATE.REVEALED) return;
     cell.state = CELL_STATE.REVEALED;
     if (cell.mineCount === 0) _chordCells(config, board, _x, _y);
   });
-};
+}
 
 /**
  * Counts how many mines are on the board, subtracting the number of flags that
  *  have been placed.
  */
-export const getMineDisplayCount = (board: MinesweeperBoard): number => {
+export function getMineDisplayCount(board: MinesweeperBoard): number {
   let _numberOfMines = 0;
   let _numberOfFlags = 0;
 
@@ -391,6 +391,56 @@ export const getMineDisplayCount = (board: MinesweeperBoard): number => {
   }
 
   return _numberOfMines - _numberOfFlags;
+}
+
+/**
+ * Determines whether or not a board is in the win condition.
+ */
+export function determineBoardState(board: MinesweeperBoard): GAME_STATE {
+  let isSeeded = false;
+
+  // The game is won when all non-mine cells are revealed.
+  let hasUnrevealedCells = false;
+
+  // Don't want to count a board with no cells as "won".
+  let hasCells = false;
+
+  for (const row of board) {
+    for (const cell of row) {
+      hasCells = true;
+      if (cell.hasMine) isSeeded = true;
+
+      switch (cell.state) {
+        case CELL_STATE.DEFAULT:
+        case CELL_STATE.QUESTIONED:
+        case CELL_STATE.FLAGGED:
+          if (!cell.hasMine) hasUnrevealedCells = true;
+          break;
+
+        case CELL_STATE.REVEALED:
+          if (cell.hasMine) {
+            // A mine was revealed, so the game is lost.
+            return GAME_STATE.LOSE;
+          }
+
+          break;
+      }
+    }
+  }
+
+  // By this point, we know the game isn't lost.
+
+  if (!hasCells) {
+    // If there aren't any cells at all, it's the DEFAULT state.
+    return GAME_STATE.DEFAULT;
+  }
+
+  if (hasUnrevealedCells) {
+    // There are some cells left to reveal, so the game isn't won.
+    return isSeeded ? GAME_STATE.SEEDED : GAME_STATE.DEFAULT;
+  } else {
+    return GAME_STATE.WIN;
+  }
 }
 
 /**

--- a/src/logic/board/index.test.ts
+++ b/src/logic/board/index.test.ts
@@ -1,5 +1,9 @@
 /* eslint-env jest */
-import { restoreRandom, seedRandom } from "../../../utils/test.utils";
+import {
+  getSeededBoard,
+  restoreRandom,
+  seedRandom,
+} from "../../../utils/test.utils";
 
 import {
   CELL_STATE,
@@ -7,7 +11,7 @@ import {
   CONFIG_EASY,
   CONFIG_EXPERT,
   CONFIG_INTERMEDIATE,
-  GAME_STATE
+  GAME_STATE,
 } from "../../lib/constants";
 import { OutOfBoundsError } from "../../lib/utils";
 
@@ -23,7 +27,7 @@ const expectBlankBoard = (
       expect(board?.[j]?.[i]).toEqual({
         hasMine: false,
         mineCount: 0,
-        state: CELL_STATE.DEFAULT
+        state: CELL_STATE.DEFAULT,
       });
     }
   }
@@ -32,7 +36,7 @@ const expectBlankBoard = (
 it("should return the current state if action type is unrecognized", () => {
   const stateBefore = init(CONFIG_DEFAULT);
   const action = {
-    type: "bogus_action"
+    type: "bogus_action",
   };
   const result = reducer(stateBefore, action as any);
   expect(result).toBe(stateBefore);
@@ -46,7 +50,7 @@ describe("RECONFIGURE_BOARD", () => {
     expect(result).toEqual({
       ...stateBefore,
       board: [],
-      config: CONFIG_DEFAULT
+      config: CONFIG_DEFAULT,
     });
   });
 
@@ -165,6 +169,33 @@ describe("REVEAL_CELL", () => {
         }
       })
     );
+  });
+
+  it("should go to WIN if all non-mine cells are revealed", () => {
+    const board = getSeededBoard(CONFIG_EASY);
+
+    for (const row of board) {
+      for (const cell of row) {
+        // Reveal every non-mine cell.
+        if (!cell.hasMine) cell.state = CELL_STATE.REVEALED;
+      }
+    }
+
+    const actionX = 0;
+    const actionY = 4;
+
+    // Unreveal the cell to be revealed.
+    board[actionY][actionX].state = CELL_STATE.DEFAULT;
+
+    const stateBefore = {
+      ...init(CONFIG_EASY),
+      board,
+      gameState: GAME_STATE.SEEDED,
+    };
+    const action = revealCell(actionX, actionY);
+    const result = reducer(stateBefore, action);
+
+    expect(result.gameState).toBe(GAME_STATE.WIN);
   });
 });
 

--- a/src/logic/board/index.test.ts
+++ b/src/logic/board/index.test.ts
@@ -15,7 +15,13 @@ import {
 } from "../../lib/constants";
 import { OutOfBoundsError } from "../../lib/utils";
 
-import { init, reconfigureBoard, reducer, revealCell } from "./index";
+import {
+  BoardState,
+  init,
+  reconfigureBoard,
+  reducer,
+  revealCell,
+} from "./index";
 import { MinesweeperBoard, MinesweeperConfig } from "../../types";
 
 const expectBlankBoard = (
@@ -87,6 +93,34 @@ describe("REVEAL_CELL", () => {
   afterEach(() => {
     restoreRandom();
   });
+
+  /**
+   * Convenience function to construct and enacta `BoardState` that is won.
+   */
+  function getWonState(): BoardState {
+    const board = getSeededBoard(CONFIG_EASY);
+
+    for (const row of board) {
+      for (const cell of row) {
+        // Reveal every non-mine cell.
+        if (!cell.hasMine) cell.state = CELL_STATE.REVEALED;
+      }
+    }
+
+    const actionX = 0;
+    const actionY = 4;
+
+    // Unreveal the cell to be revealed.
+    board[actionY][actionX].state = CELL_STATE.DEFAULT;
+
+    const stateBefore = {
+      ...init(CONFIG_EASY),
+      board,
+      gameState: GAME_STATE.SEEDED,
+    };
+    const action = revealCell(actionX, actionY);
+    return reducer(stateBefore, action);
+  }
 
   it("should throw an error for a default board", () => {
     const stateBefore = init(CONFIG_DEFAULT);
@@ -171,31 +205,20 @@ describe("REVEAL_CELL", () => {
     );
   });
 
-  it("should go to WIN if all non-mine cells are revealed", () => {
-    const board = getSeededBoard(CONFIG_EASY);
-
-    for (const row of board) {
-      for (const cell of row) {
-        // Reveal every non-mine cell.
-        if (!cell.hasMine) cell.state = CELL_STATE.REVEALED;
-      }
-    }
-
-    const actionX = 0;
-    const actionY = 4;
-
-    // Unreveal the cell to be revealed.
-    board[actionY][actionX].state = CELL_STATE.DEFAULT;
-
-    const stateBefore = {
-      ...init(CONFIG_EASY),
-      board,
-      gameState: GAME_STATE.SEEDED,
-    };
-    const action = revealCell(actionX, actionY);
-    const result = reducer(stateBefore, action);
+  it("should flag all mines go to WIN if all non-mine cells are revealed", () => {
+    const result = getWonState();
 
     expect(result.gameState).toBe(GAME_STATE.WIN);
+  });
+
+  it("should flag all mines if all non-mine cells are revealed", () => {
+    const result = getWonState();
+
+    for (const row of result.board) {
+      for (const cell of row) {
+        if (cell.hasMine) expect(cell.state).toBe(CELL_STATE.FLAGGED);
+      }
+    }
   });
 });
 

--- a/src/logic/board/index.ts
+++ b/src/logic/board/index.ts
@@ -11,13 +11,14 @@ import {
 import {
   chordCells,
   determineBoardState,
+  flagAllMines,
   getBoard,
   placeMines,
   OutOfBoundsError,
 } from "../../lib/utils";
 import { CELL_STATE, GAME_STATE } from "../../lib/constants";
 
-interface BoardState {
+export interface BoardState {
   board: MinesweeperBoard;
   config: MinesweeperConfig;
   gameState: GAME_STATE;
@@ -111,6 +112,11 @@ export function reducer(state: BoardState, action: BoardAction): BoardState {
       const newState = cell.hasMine
         ? GAME_STATE.LOSE
         : determineBoardState(newBoard);
+
+      // If the game was just won, make sure to flag all the cells.
+      if (newState === GAME_STATE.WIN) {
+        flagAllMines(newBoard);
+      }
 
       return {
         ...state,


### PR DESCRIPTION
* Adds `determineBoardState` to `src/lib/utils`.
  * Refactors the `REVEAL_CELL` logic in the reducer to use this instead of having all the logic to determine the state in there.
* Adds `flagAllMines` to `src/lib/utils`.
* Sets the mine display count to 0 and flags are mines when the game enters the `WIN` state.
  * `getMineDisplayCount` now takes a `GAME_STATE` as its second parameter.