### PR TITLE
Closes #21 - Allow the changing of difficulty (not custom)

### DIFF
--- a/__mocks__/electron.ts
+++ b/__mocks__/electron.ts
@@ -49,7 +49,9 @@ class TestIpcRenderer {
     }
   }
 
-  send(channel: string, ...args: any[]) {
+  send(channel: string, ...args: any[]) {}
+
+  _simulate(channel: string, ...args: any[]) {
     const event: TestIpcRendererEvent = {
       preventDefault: () => {},
       sender: this,

--- a/__mocks__/electron.ts
+++ b/__mocks__/electron.ts
@@ -53,9 +53,9 @@ class TestIpcRenderer {
     const event: TestIpcRendererEvent = {
       preventDefault: () => {},
       sender: this,
-      senderId: 0
+      senderId: 0,
     };
-    this._channels[channel]?.forEach(listener => listener(event, ...args));
+    this._channels[channel]?.forEach((listener) => listener(event, ...args));
   }
 
   sendSync: never;

--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useReducer } from "react";
+import React, { useMemo } from "react";
 
 import { GAME_STATE } from "../lib/constants";
 
@@ -35,6 +35,7 @@ const Board: React.FC<BoardProps> = ({
     }
   };
 
+  // Functional styling.
   const tableStyle = useMemo(() => ({ borderSpacing: 0, ...style }), [style]);
 
   return (

--- a/src/components/Game.test.tsx
+++ b/src/components/Game.test.tsx
@@ -184,3 +184,29 @@ describe("The 'Expert' IPC channel", () => {
     ).toBe(0);
   });
 });
+
+it("should allow switching back and forth between difficulties", () => {
+  setUp({ initialConfig: CONFIG_EASY });
+
+  // Ensure the easy configuration was used (for sanity).
+  let cells = document.querySelectorAll(".cell");
+  expect(cells.length).toBe(CONFIG_EASY.x * CONFIG_EASY.y);
+
+  // Switch difficulty.
+  act(() => {
+    ipcRenderer.send(IPC_MESSAGE.DIFFICULTY_INTERMEDIATE);
+  });
+
+  // Verify the game was reconfigured appropriately.
+  cells = document.querySelectorAll(".cell");
+  expect(cells.length).toBe(CONFIG_INTERMEDIATE.x * CONFIG_INTERMEDIATE.y);
+
+  // Switch difficult back.
+  act(() => {
+    ipcRenderer.send(IPC_MESSAGE.DIFFICULTY_BEGINNER);
+  });
+
+  // Verify it switched back to the original difficulty.
+  cells = document.querySelectorAll(".cell");
+  expect(cells.length).toBe(CONFIG_EASY.x * CONFIG_EASY.y);
+});

--- a/src/components/Game.test.tsx
+++ b/src/components/Game.test.tsx
@@ -16,7 +16,7 @@ import {
   CONFIG_EXPERT,
 } from "../lib/constants";
 
-import { IPC_MESSAGE } from "../electron";
+import { IPC_CHANNEL_RENDERER } from "../electron";
 import { MinesweeperConfig } from "../types";
 
 import Game, { GameProps } from "./Game";
@@ -74,7 +74,8 @@ describe("The 'New Game' IPC channel", () => {
     expect(revealedCells.length).toBe(53);
 
     act(() => {
-      ipcRenderer.send(IPC_MESSAGE.NEW_GAME);
+      // @ts-ignore
+      ipcRenderer._simulate(IPC_CHANNEL_RENDERER.NEW_GAME);
     });
 
     expect(document.querySelectorAll(".revealed").length).toBe(0);
@@ -84,14 +85,14 @@ describe("The 'New Game' IPC channel", () => {
     const { unmount } = setUp();
 
     // @ts-ignore
-    expect(ipcRenderer._channels[IPC_MESSAGE.NEW_GAME]?.length).not.toBe(0);
+    expect(ipcRenderer._channels[IPC_CHANNEL_RENDERER.NEW_GAME]?.length).not.toBe(0);
 
     act(() => {
       unmount();
     });
 
     // @ts-ignore
-    expect(ipcRenderer._channels[IPC_MESSAGE.NEW_GAME]?.length).toBe(0);
+    expect(ipcRenderer._channels[IPC_CHANNEL_RENDERER.NEW_GAME]?.length).toBe(0);
   });
 });
 
@@ -105,7 +106,8 @@ function difficultyTest(channel: string, config: MinesweeperConfig) {
   expect(cells.length).toBe(0);
 
   act(() => {
-    ipcRenderer.send(channel);
+    // @ts-ignore
+    ipcRenderer._simulate(channel);
   });
 
   // Verify the game was reconfigured appropriately.
@@ -115,7 +117,7 @@ function difficultyTest(channel: string, config: MinesweeperConfig) {
 
 describe("The 'Beginner' IPC channel", () => {
   it("should reconfigure the board using the EASY configuration", () => {
-    difficultyTest(IPC_MESSAGE.DIFFICULTY_BEGINNER, CONFIG_EASY);
+    difficultyTest(IPC_CHANNEL_RENDERER.DIFFICULTY_BEGINNER, CONFIG_EASY);
   });
 
   it("should be cleaned up on unmounting", () => {
@@ -123,7 +125,7 @@ describe("The 'Beginner' IPC channel", () => {
 
     expect(
       // @ts-ignore
-      ipcRenderer._channels[IPC_MESSAGE.DIFFICULTY_BEGINNER]?.length
+      ipcRenderer._channels[IPC_CHANNEL_RENDERER.DIFFICULTY_BEGINNER]?.length
     ).not.toBe(0);
 
     act(() => {
@@ -131,7 +133,7 @@ describe("The 'Beginner' IPC channel", () => {
     });
 
     // @ts-ignore
-    expect(ipcRenderer._channels[IPC_MESSAGE.DIFFICULTY_BEGINNER]?.length).toBe(
+    expect(ipcRenderer._channels[IPC_CHANNEL_RENDERER.DIFFICULTY_BEGINNER]?.length).toBe(
       0
     );
   });
@@ -139,7 +141,7 @@ describe("The 'Beginner' IPC channel", () => {
 
 describe("The 'Intermediate' IPC channel", () => {
   it("should reconfigure the board using the INTERMEDIATE configuration", () => {
-    difficultyTest(IPC_MESSAGE.DIFFICULTY_INTERMEDIATE, CONFIG_INTERMEDIATE);
+    difficultyTest(IPC_CHANNEL_RENDERER.DIFFICULTY_INTERMEDIATE, CONFIG_INTERMEDIATE);
   });
 
   it("should be cleaned up on unmounting", () => {
@@ -147,7 +149,7 @@ describe("The 'Intermediate' IPC channel", () => {
 
     expect(
       // @ts-ignore
-      ipcRenderer._channels[IPC_MESSAGE.DIFFICULTY_INTERMEDIATE]?.length
+      ipcRenderer._channels[IPC_CHANNEL_RENDERER.DIFFICULTY_INTERMEDIATE]?.length
     ).not.toBe(0);
 
     act(() => {
@@ -156,14 +158,14 @@ describe("The 'Intermediate' IPC channel", () => {
 
     expect(
       // @ts-ignore
-      ipcRenderer._channels[IPC_MESSAGE.DIFFICULTY_INTERMEDIATE]?.length
+      ipcRenderer._channels[IPC_CHANNEL_RENDERER.DIFFICULTY_INTERMEDIATE]?.length
     ).toBe(0);
   });
 });
 
 describe("The 'Expert' IPC channel", () => {
   it("should reconfigure the board using the EXPERT configuration", () => {
-    difficultyTest(IPC_MESSAGE.DIFFICULTY_EXPERT, CONFIG_EXPERT);
+    difficultyTest(IPC_CHANNEL_RENDERER.DIFFICULTY_EXPERT, CONFIG_EXPERT);
   });
 
   it("should be cleaned up on unmounting", () => {
@@ -171,7 +173,7 @@ describe("The 'Expert' IPC channel", () => {
 
     expect(
       // @ts-ignore
-      ipcRenderer._channels[IPC_MESSAGE.DIFFICULTY_EXPERT]?.length
+      ipcRenderer._channels[IPC_CHANNEL_RENDERER.DIFFICULTY_EXPERT]?.length
     ).not.toBe(0);
 
     act(() => {
@@ -180,7 +182,7 @@ describe("The 'Expert' IPC channel", () => {
 
     expect(
       // @ts-ignore
-      ipcRenderer._channels[IPC_MESSAGE.DIFFICULTY_EXPERT]?.length
+      ipcRenderer._channels[IPC_CHANNEL_RENDERER.DIFFICULTY_EXPERT]?.length
     ).toBe(0);
   });
 });
@@ -194,7 +196,8 @@ it("should allow switching back and forth between difficulties", () => {
 
   // Switch difficulty.
   act(() => {
-    ipcRenderer.send(IPC_MESSAGE.DIFFICULTY_INTERMEDIATE);
+    // @ts-ignore
+    ipcRenderer._simulate(IPC_CHANNEL_RENDERER.DIFFICULTY_INTERMEDIATE);
   });
 
   // Verify the game was reconfigured appropriately.
@@ -203,7 +206,8 @@ it("should allow switching back and forth between difficulties", () => {
 
   // Switch difficult back.
   act(() => {
-    ipcRenderer.send(IPC_MESSAGE.DIFFICULTY_BEGINNER);
+    // @ts-ignore
+    ipcRenderer._simulate(IPC_CHANNEL_RENDERER.DIFFICULTY_BEGINNER);
   });
 
   // Verify it switched back to the original difficulty.

--- a/src/components/Game.test.tsx
+++ b/src/components/Game.test.tsx
@@ -9,7 +9,7 @@ import {
   restoreRandom,
 } from "../../utils/test.utils";
 
-import { IPC_MESSAGE } from "../lib/constants";
+import { IPC_MESSAGE } from "../electron";
 
 import Game from "./Game";
 

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -32,19 +32,11 @@ const Game: React.FC<GameProps> = ({ initialConfig, ...props }) => {
   );
 
   useEffect(() => {
-    // If the provided `config` is different than the current one, reconfigures
-    //  the board.
-    function changeConfig(config: MinesweeperConfig) {
-      // This won't catch duplicate custom configs, but that's probably fine.
-      if (state.config !== config) {
-        dispatch(reconfigureBoard(config));
-      }
-    }
-
     // Set up listeners for IPC channels from the main process.
-    const beginnerListener = () => changeConfig(CONFIG_EASY);
-    const expertListener = () => changeConfig(CONFIG_EXPERT);
-    const intermediateListener = () => changeConfig(CONFIG_INTERMEDIATE);
+    const beginnerListener = () => dispatch(reconfigureBoard(CONFIG_EASY));
+    const expertListener = () => dispatch(reconfigureBoard(CONFIG_EXPERT));
+    const intermediateListener = () =>
+      dispatch(reconfigureBoard(CONFIG_INTERMEDIATE));
     const newGameListener = () => dispatch(reconfigureBoard(state.config));
 
     ipcRenderer.on(IPC_MESSAGE.DIFFICULTY_BEGINNER, beginnerListener);

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -2,6 +2,7 @@ import { ipcRenderer } from "electron";
 import React, { useReducer, useEffect, HTMLAttributes } from "react";
 import { castDraft } from "immer";
 
+import assert from "../lib/assert";
 import {
   CONFIG_EASY,
   CONFIG_INTERMEDIATE,
@@ -14,11 +15,13 @@ import {
   revealCell,
   turnCellState,
 } from "../logic/board";
-import { IPC_MESSAGE } from "../electron";
+import { IPC_CHANNEL_MAIN, IPC_CHANNEL_RENDERER } from "../electron";
 import { MinesweeperConfig } from "../types";
 
 import Board from "./Board";
 import Tray from "./Tray";
+
+const TRAY_ID = "minesweeper-game-tray";
 
 export interface GameProps extends HTMLAttributes<HTMLElement> {
   initialConfig?: MinesweeperConfig;
@@ -31,30 +34,59 @@ const Game: React.FC<GameProps> = ({ initialConfig, ...props }) => {
     init
   );
 
+  function changeDifficulty(config: MinesweeperConfig) {
+    // Change the game's underlying configuration.
+    dispatch(reconfigureBoard(config));
+
+    // Then resize the application window based on the new content size.
+    const trayElement = document.getElementById(TRAY_ID);
+    assert(trayElement);
+
+    const windowRect = trayElement.getBoundingClientRect();
+
+    // Send the message to the main process to resize the application window.
+    // - We need to let the main process handle this (as opposed to importing
+    //   `remote`) because Electron doesn't take the application menu into
+    //   account when setting the content size.
+    ipcRenderer.send(
+      IPC_CHANNEL_MAIN.RESIZE_WINDOW,
+      windowRect.width,
+      windowRect.height
+    );
+  }
+
   useEffect(() => {
     // Set up listeners for IPC channels from the main process.
-    const beginnerListener = () => dispatch(reconfigureBoard(CONFIG_EASY));
-    const expertListener = () => dispatch(reconfigureBoard(CONFIG_EXPERT));
-    const intermediateListener = () =>
-      dispatch(reconfigureBoard(CONFIG_INTERMEDIATE));
+    const beginnerListener = () => changeDifficulty(CONFIG_EASY);
+    const expertListener = () => changeDifficulty(CONFIG_EXPERT);
+    const intermediateListener = () => changeDifficulty(CONFIG_INTERMEDIATE);
     const newGameListener = () => dispatch(reconfigureBoard(state.config));
 
-    ipcRenderer.on(IPC_MESSAGE.DIFFICULTY_BEGINNER, beginnerListener);
-    ipcRenderer.on(IPC_MESSAGE.DIFFICULTY_EXPERT, expertListener);
-    ipcRenderer.on(IPC_MESSAGE.DIFFICULTY_INTERMEDIATE, intermediateListener);
-    ipcRenderer.on(IPC_MESSAGE.NEW_GAME, newGameListener);
+    ipcRenderer.on(IPC_CHANNEL_RENDERER.DIFFICULTY_BEGINNER, beginnerListener);
+    ipcRenderer.on(IPC_CHANNEL_RENDERER.DIFFICULTY_EXPERT, expertListener);
+    ipcRenderer.on(
+      IPC_CHANNEL_RENDERER.DIFFICULTY_INTERMEDIATE,
+      intermediateListener
+    );
+    ipcRenderer.on(IPC_CHANNEL_RENDERER.NEW_GAME, newGameListener);
 
     return () => {
       ipcRenderer.removeListener(
-        IPC_MESSAGE.DIFFICULTY_BEGINNER,
+        IPC_CHANNEL_RENDERER.DIFFICULTY_BEGINNER,
         beginnerListener
       );
-      ipcRenderer.removeListener(IPC_MESSAGE.DIFFICULTY_EXPERT, expertListener);
       ipcRenderer.removeListener(
-        IPC_MESSAGE.DIFFICULTY_INTERMEDIATE,
+        IPC_CHANNEL_RENDERER.DIFFICULTY_EXPERT,
+        expertListener
+      );
+      ipcRenderer.removeListener(
+        IPC_CHANNEL_RENDERER.DIFFICULTY_INTERMEDIATE,
         intermediateListener
       );
-      ipcRenderer.removeListener(IPC_MESSAGE.NEW_GAME, newGameListener);
+      ipcRenderer.removeListener(
+        IPC_CHANNEL_RENDERER.NEW_GAME,
+        newGameListener
+      );
     };
   }, []);
 
@@ -63,6 +95,7 @@ const Game: React.FC<GameProps> = ({ initialConfig, ...props }) => {
       {...props}
       board={castDraft(state.board)}
       gameState={state.gameState}
+      id={TRAY_ID}
       onSmileyClick={() => dispatch(reconfigureBoard(state.config))}
     >
       <Board

--- a/src/components/Tray.css
+++ b/src/components/Tray.css
@@ -6,7 +6,7 @@
 }
 
 .container {
-  width: fit-content;
+  width: max-content;
   border: calc(4px * var(--size-scale)) solid var(--bg-color-light);
   padding: calc(6px * var(--size-scale));
   background-color: var(--bg-color-primary);

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -1,10 +1,18 @@
 import { BrowserWindow } from "electron";
 
 /**
- * Enum representing the Electron IPC message channels.
+ * Enum representing the Electron IPC message channels for the main process.
  * @private
  */
-export enum IPC_MESSAGE {
+export enum IPC_CHANNEL_MAIN {
+  RESIZE_WINDOW = "resize-window"
+}
+
+/**
+ * Enum representing the Electron IPC message channels for the renderer process.
+ * @private
+ */
+export enum IPC_CHANNEL_RENDERER {
   DIFFICULTY_BEGINNER = "difficulty-beginner",
   DIFFICULTY_EXPERT = "difficulty-expert",
   DIFFICULTY_INTERMEDIATE = "difficulty-intermediate",
@@ -18,7 +26,7 @@ export enum IPC_MESSAGE {
  */
 export const getSimpleIpcNotifier = (
   window: BrowserWindow,
-  channel: IPC_MESSAGE
+  channel: IPC_CHANNEL_RENDERER
 ) => () => {
   // Send a message to the renderer process.
   window.webContents.send(channel);

--- a/src/electron.ts
+++ b/src/electron.ts
@@ -1,0 +1,25 @@
+import { BrowserWindow } from "electron";
+
+/**
+ * Enum representing the Electron IPC message channels.
+ * @private
+ */
+export enum IPC_MESSAGE {
+  DIFFICULTY_BEGINNER = "difficulty-beginner",
+  DIFFICULTY_EXPERT = "difficulty-expert",
+  DIFFICULTY_INTERMEDIATE = "difficulty-intermediate",
+  NEW_GAME = "new-game",
+}
+
+/**
+ * Generates a very simple IPC channel notifier.
+ * @param window
+ * @param channel - The IPC channel to which to notify.
+ */
+export const getSimpleIpcNotifier = (
+  window: BrowserWindow,
+  channel: IPC_MESSAGE
+) => () => {
+  // Send a message to the renderer process.
+  window.webContents.send(channel);
+};

--- a/src/index.html
+++ b/src/index.html
@@ -30,7 +30,7 @@
       }
     </style>
   </head>
-  <body>
+  <body style="overflow: hidden;">
     <div id="root"></div>
   </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import { app, BrowserWindow, Menu, MenuItemConstructorOptions } from "electron";
+import { app, BrowserWindow, Menu } from "electron";
 
-import { IPC_MESSAGE, getSimpleIpcNotifier } from "./electron";
+import { getMenuTemplate } from "./main/menu";
 
 declare const MAIN_WINDOW_WEBPACK_ENTRY: any;
 
@@ -21,80 +21,7 @@ const createWindow = () => {
     width: 800,
   });
 
-  const menuTemplate: MenuItemConstructorOptions[] = [
-    {
-      label: "Game",
-      submenu: [
-        /* New */
-        {
-          label: "New",
-          accelerator: "F2",
-          click: getSimpleIpcNotifier(mainWindow, IPC_MESSAGE.NEW_GAME),
-        },
-
-        // --------------------------------------------------------------------
-        { type: "separator" },
-
-        /* Difficulties */
-        {
-          label: "Beginner",
-          type: "checkbox",
-          click: getSimpleIpcNotifier(
-            mainWindow,
-            IPC_MESSAGE.DIFFICULTY_BEGINNER
-          ),
-          checked: true,
-        },
-        {
-          label: "Intermediate",
-          type: "checkbox",
-          click: getSimpleIpcNotifier(
-            mainWindow,
-            IPC_MESSAGE.DIFFICULTY_INTERMEDIATE
-          ),
-        },
-        {
-          label: "Expert",
-          type: "checkbox",
-          click: getSimpleIpcNotifier(
-            mainWindow,
-            IPC_MESSAGE.DIFFICULTY_EXPERT
-          ),
-        },
-        { label: "Custom...", type: "checkbox", enabled: false },
-
-        // --------------------------------------------------------------------
-        { type: "separator" },
-
-        /* Configuration options */
-        { label: "Marks (?)", type: "checkbox", enabled: false, checked: true },
-        { label: "Color", type: "checkbox", enabled: false, checked: true },
-        { label: "Sound", type: "checkbox", enabled: false },
-
-        // --------------------------------------------------------------------
-        { type: "separator" },
-
-        /* Best times */
-        { label: "Best Times...", enabled: false },
-
-        // --------------------------------------------------------------------
-        { type: "separator" },
-
-        /* Exit */
-        { label: "Exit", role: "quit" },
-      ],
-    },
-    {
-      label: "Help",
-      submenu: [
-        { label: "Contents", accelerator: "F1", enabled: false },
-        { label: "Search for Help on...", enabled: false },
-        { label: "Using Help", enabled: false },
-        { type: "separator" },
-        { label: "About Minesweeper...", enabled: false },
-      ],
-    },
-  ];
+  const menuTemplate = getMenuTemplate(mainWindow);
 
   if (isMac) {
     menuTemplate.unshift({ role: "appMenu" });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, Menu, MenuItemConstructorOptions } from "electron";
 
-import { IPC_MESSAGE } from "./lib/constants";
+import { IPC_MESSAGE, getSimpleIpcNotifier } from "./electron";
 
 declare const MAIN_WINDOW_WEBPACK_ENTRY: any;
 
@@ -16,37 +16,73 @@ const createWindow = () => {
   const mainWindow = new BrowserWindow({
     height: 600,
     webPreferences: {
-      nodeIntegration: true
+      nodeIntegration: true,
     },
-    width: 800
+    width: 800,
   });
 
   const menuTemplate: MenuItemConstructorOptions[] = [
     {
       label: "Game",
       submenu: [
+        /* New */
         {
           label: "New",
           accelerator: "F2",
-          click: () => {
-            // Send a message to the renderer process.
-            mainWindow.webContents.send(IPC_MESSAGE.NEW_GAME);
-          }
+          click: getSimpleIpcNotifier(mainWindow, IPC_MESSAGE.NEW_GAME),
         },
+
+        // --------------------------------------------------------------------
         { type: "separator" },
-        { label: "Beginner", type: "checkbox", enabled: false, checked: true },
-        { label: "Intermediate", type: "checkbox", enabled: false },
-        { label: "Expert", type: "checkbox", enabled: false },
+
+        /* Difficulties */
+        {
+          label: "Beginner",
+          type: "checkbox",
+          click: getSimpleIpcNotifier(
+            mainWindow,
+            IPC_MESSAGE.DIFFICULTY_BEGINNER
+          ),
+          checked: true,
+        },
+        {
+          label: "Intermediate",
+          type: "checkbox",
+          click: getSimpleIpcNotifier(
+            mainWindow,
+            IPC_MESSAGE.DIFFICULTY_INTERMEDIATE
+          ),
+        },
+        {
+          label: "Expert",
+          type: "checkbox",
+          click: getSimpleIpcNotifier(
+            mainWindow,
+            IPC_MESSAGE.DIFFICULTY_EXPERT
+          ),
+        },
         { label: "Custom...", type: "checkbox", enabled: false },
+
+        // --------------------------------------------------------------------
         { type: "separator" },
+
+        /* Configuration options */
         { label: "Marks (?)", type: "checkbox", enabled: false, checked: true },
         { label: "Color", type: "checkbox", enabled: false, checked: true },
         { label: "Sound", type: "checkbox", enabled: false },
+
+        // --------------------------------------------------------------------
         { type: "separator" },
+
+        /* Best times */
         { label: "Best Times...", enabled: false },
+
+        // --------------------------------------------------------------------
         { type: "separator" },
-        { label: "Exit", role: "quit" }
-      ]
+
+        /* Exit */
+        { label: "Exit", role: "quit" },
+      ],
     },
     {
       label: "Help",
@@ -55,9 +91,9 @@ const createWindow = () => {
         { label: "Search for Help on...", enabled: false },
         { label: "Using Help", enabled: false },
         { type: "separator" },
-        { label: "About Minesweeper...", enabled: false }
-      ]
-    }
+        { label: "About Minesweeper...", enabled: false },
+      ],
+    },
   ];
 
   if (isMac) {

--- a/src/lib/assert.ts
+++ b/src/lib/assert.ts
@@ -1,0 +1,13 @@
+import { AssertionError } from "assert";
+
+function ok(condition: any, error?: string | Error): asserts condition {
+  if (!condition) {
+    const _error =
+      typeof error === "string"
+        ? new AssertionError({ message: error })
+        : error;
+    throw _error;
+  }
+}
+
+export default ok;

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -55,12 +55,3 @@ export enum GAME_STATE {
   /** A state representing the player having won. B) */
   WIN,
 }
-
-// TODO: Move out of this file; this is Electron-specific.
-/**
- * Enum representing the Electron IPC message channels.
- * @private
- */
-export enum IPC_MESSAGE {
-  NEW_GAME = "new-game",
-}

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,0 +1,196 @@
+import assert from "../lib/assert";
+import {
+  BrowserWindow,
+  Menu,
+  MenuItem,
+  MenuItemConstructorOptions,
+} from "electron";
+
+import { IPC_MESSAGE, getSimpleIpcNotifier } from "../electron";
+
+enum MENU_ID {
+  GAME = "game",
+  HELP = "help",
+}
+
+enum GAME_MENU_ID {
+  BEST_TIMES = "best_times",
+  CONFIG_COLOR = "config_color",
+  CONFIG_MARKS = "config_marks",
+  CONFIG_SOUND = "config_sound",
+  DIFFICULTY_BEGINNER = "diff_beginner",
+  DIFFICULTY_CUSTOM = "diff_custom",
+  DIFFICULTY_INTERMEDIATE = "diff_intermediate",
+  DIFFICULTY_EXPERT = "diff_expert",
+  EXIT = "exit",
+  NEW = "new",
+}
+
+function uncheckMenuItem(menu: Menu, id: string) {
+  const menuItem = menu.items.find((item) => item.id === id);
+
+  assert(menuItem, `Menu item not found: "${id}"`);
+  assert(
+    menuItem.type === "checkbox" || menuItem.type === "radio",
+    `Invalid menu item type: ${menuItem.type}`
+  );
+
+  menuItem.checked = false;
+}
+
+export function getMenuTemplate(
+  window: BrowserWindow
+): MenuItemConstructorOptions[] {
+  function getDifficultyClickHandler(id: GAME_MENU_ID, channel: IPC_MESSAGE) {
+    return (menuItem: MenuItem) => {
+      const gameMenu = Menu.getApplicationMenu()?.items.find(
+        ({ id }) => id === MENU_ID.GAME
+      )?.submenu;
+
+      assert(gameMenu, "No game menu found!");
+
+      /**
+       * Okay... So the menu in the XP version of Minesweeper PRESENTS the
+       *  difficulty options as checkboxes but TREATS them as radio buttons.
+       *  Since Electron actually treats checkboxes like checkboxes, we need to
+       *  manually ensure the user can't "turn off" the difficulty option.
+       */
+      if (!menuItem.checked) {
+        /**
+         * NOTE: This click handler gets called AFTER the `checked` value has
+         *  already been toggled.
+         */
+        menuItem.checked = true;
+        return;
+      }
+
+      if (id !== GAME_MENU_ID.DIFFICULTY_BEGINNER)
+        uncheckMenuItem(gameMenu, GAME_MENU_ID.DIFFICULTY_BEGINNER);
+      if (id !== GAME_MENU_ID.DIFFICULTY_CUSTOM)
+        uncheckMenuItem(gameMenu, GAME_MENU_ID.DIFFICULTY_CUSTOM);
+      if (id !== GAME_MENU_ID.DIFFICULTY_EXPERT)
+        uncheckMenuItem(gameMenu, GAME_MENU_ID.DIFFICULTY_EXPERT);
+      if (id !== GAME_MENU_ID.DIFFICULTY_INTERMEDIATE)
+        uncheckMenuItem(gameMenu, GAME_MENU_ID.DIFFICULTY_INTERMEDIATE);
+
+      getSimpleIpcNotifier(window, channel)();
+    };
+  }
+
+  return [
+    /* Game Menu */
+    {
+      id: MENU_ID.GAME,
+      label: "Game",
+      submenu: [
+        /* New */
+        {
+          accelerator: "F2",
+          click: getSimpleIpcNotifier(window, IPC_MESSAGE.NEW_GAME),
+          id: GAME_MENU_ID.NEW,
+          label: "New",
+        },
+
+        // --------------------------------------------------------------------
+        { type: "separator" },
+
+        /* Difficulties */
+        {
+          checked: true,
+          click: getDifficultyClickHandler(
+            GAME_MENU_ID.DIFFICULTY_BEGINNER,
+            IPC_MESSAGE.DIFFICULTY_BEGINNER
+          ),
+          id: GAME_MENU_ID.DIFFICULTY_BEGINNER,
+          label: "Beginner",
+          type: "checkbox",
+        },
+        {
+          click: getDifficultyClickHandler(
+            GAME_MENU_ID.DIFFICULTY_INTERMEDIATE,
+            IPC_MESSAGE.DIFFICULTY_INTERMEDIATE
+          ),
+          id: GAME_MENU_ID.DIFFICULTY_INTERMEDIATE,
+          label: "Intermediate",
+          type: "checkbox",
+        },
+        {
+          click: getDifficultyClickHandler(
+            GAME_MENU_ID.DIFFICULTY_EXPERT,
+            IPC_MESSAGE.DIFFICULTY_EXPERT
+          ),
+          id: GAME_MENU_ID.DIFFICULTY_EXPERT,
+          label: "Expert",
+          type: "checkbox",
+        },
+        {
+          enabled: false,
+          id: GAME_MENU_ID.DIFFICULTY_CUSTOM,
+          label: "Custom...",
+          type: "checkbox",
+        },
+
+        // --------------------------------------------------------------------
+        { type: "separator" },
+
+        /* Configuration Options */
+        {
+          checked: true,
+          enabled: false,
+          id: GAME_MENU_ID.CONFIG_MARKS,
+          label: "Marks (?)",
+          type: "checkbox",
+        },
+        {
+          checked: true,
+          enabled: false,
+          id: GAME_MENU_ID.CONFIG_COLOR,
+          label: "Color",
+          type: "checkbox",
+        },
+        {
+          enabled: false,
+          id: GAME_MENU_ID.CONFIG_SOUND,
+          label: "Sound",
+          type: "checkbox",
+        },
+
+        // --------------------------------------------------------------------
+        { type: "separator" },
+
+        /* Best Times */
+        {
+          enabled: false,
+          id: GAME_MENU_ID.BEST_TIMES,
+          label: "Best Times...",
+        },
+
+        // --------------------------------------------------------------------
+        { type: "separator" },
+
+        /* Exit */
+        {
+          id: GAME_MENU_ID.EXIT,
+          label: "Exit",
+          role: "quit",
+        },
+      ],
+    },
+
+    /* Help Menu */
+    {
+      id: MENU_ID.HELP,
+      label: "Help",
+      submenu: [
+        { label: "Contents", accelerator: "F1", enabled: false },
+        { label: "Search for Help on...", enabled: false },
+        { label: "Using Help", enabled: false },
+
+        // --------------------------------------------------------------------
+        { type: "separator" },
+
+        { label: "About Minesweeper...", enabled: false },
+      ],
+    },
+  ];
+}

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -6,7 +6,7 @@ import {
   MenuItemConstructorOptions,
 } from "electron";
 
-import { IPC_MESSAGE, getSimpleIpcNotifier } from "../electron";
+import { IPC_CHANNEL_RENDERER, getSimpleIpcNotifier } from "../electron";
 
 enum MENU_ID {
   GAME = "game",
@@ -41,7 +41,7 @@ function uncheckMenuItem(menu: Menu, id: string) {
 export function getMenuTemplate(
   window: BrowserWindow
 ): MenuItemConstructorOptions[] {
-  function getDifficultyClickHandler(id: GAME_MENU_ID, channel: IPC_MESSAGE) {
+  function getDifficultyClickHandler(id: GAME_MENU_ID, channel: IPC_CHANNEL_RENDERER) {
     return (menuItem: MenuItem) => {
       const gameMenu = Menu.getApplicationMenu()?.items.find(
         ({ id }) => id === MENU_ID.GAME
@@ -86,7 +86,7 @@ export function getMenuTemplate(
         /* New */
         {
           accelerator: "F2",
-          click: getSimpleIpcNotifier(window, IPC_MESSAGE.NEW_GAME),
+          click: getSimpleIpcNotifier(window, IPC_CHANNEL_RENDERER.NEW_GAME),
           id: GAME_MENU_ID.NEW,
           label: "New",
         },
@@ -99,7 +99,7 @@ export function getMenuTemplate(
           checked: true,
           click: getDifficultyClickHandler(
             GAME_MENU_ID.DIFFICULTY_BEGINNER,
-            IPC_MESSAGE.DIFFICULTY_BEGINNER
+            IPC_CHANNEL_RENDERER.DIFFICULTY_BEGINNER
           ),
           id: GAME_MENU_ID.DIFFICULTY_BEGINNER,
           label: "Beginner",
@@ -108,7 +108,7 @@ export function getMenuTemplate(
         {
           click: getDifficultyClickHandler(
             GAME_MENU_ID.DIFFICULTY_INTERMEDIATE,
-            IPC_MESSAGE.DIFFICULTY_INTERMEDIATE
+            IPC_CHANNEL_RENDERER.DIFFICULTY_INTERMEDIATE
           ),
           id: GAME_MENU_ID.DIFFICULTY_INTERMEDIATE,
           label: "Intermediate",
@@ -117,7 +117,7 @@ export function getMenuTemplate(
         {
           click: getDifficultyClickHandler(
             GAME_MENU_ID.DIFFICULTY_EXPERT,
-            IPC_MESSAGE.DIFFICULTY_EXPERT
+            IPC_CHANNEL_RENDERER.DIFFICULTY_EXPERT
           ),
           id: GAME_MENU_ID.DIFFICULTY_EXPERT,
           label: "Expert",


### PR DESCRIPTION
Closes #21 
- Abstracts application menu setup out into `src/main/menu`.
  - It started getting pretty sophisticated, and it will only get more so.
- Enables the built-in difficulty menu items.
  - Adds some logic around them to make them looks like checkboxes but behave like radio items (XP).
- Hooks up the difficulty menu items to IPC channels to tell the renderer process to reconfigure the board accordingly.
  - Also resizes the application window based on the new content size.
- Allows setting an `initialConfig` in `src/components/Game`.
  - Primarily for ease of testing, but could also be used for - say - resuming a previous game or something.
- Adds `src/lib/assert` utility.
  - Tells TS that it literally `asserts` a condition.